### PR TITLE
Fix in floating point numbers materialization

### DIFF
--- a/repository/STON-Core.package/STONReader.class/instance/parseNumber.st
+++ b/repository/STON-Core.package/STONReader.class/instance/parseNumber.st
@@ -8,11 +8,17 @@ parseNumber
 			number := Fraction numerator: number denominator: self parseNumberInteger.
 			(readStream peekFor: $s)
 				ifTrue: [ number := ScaledDecimal newFromNumber: number scale: self parseNumberInteger ] ]
-		ifFalse: [ 
+		ifFalse: [ | isFloat |
+			isFloat := false.
 			(readStream peekFor: $.)
-				ifTrue: [ number := number + self parseNumberFraction ].
+				ifTrue: [ 
+					number := number + self parseNumberFraction.
+					isFloat := true. ].
 			((readStream peekFor: $e) or: [ readStream peekFor: $E ])
-				ifTrue: [ number := number * self parseNumberExponent ] ].
+				ifTrue: [ 
+					number := number * self parseNumberExponent.
+					isFloat. ].
+			isFloat ifTrue: [ number := number asFloat  ] ].
 	negated
 		ifTrue: [ number := number negated ].
 	self consumeWhitespace.

--- a/repository/STON-Core.package/STONReader.class/instance/parseNumberFraction.st
+++ b/repository/STON-Core.package/STONReader.class/instance/parseNumberFraction.st
@@ -2,8 +2,9 @@ parsing-internal
 parseNumberFraction
 	| number power |
 	number := 0.
-	power := 1.0.
+	power := 1.
 	[ readStream atEnd not and: [ readStream peek isDigit ] ] whileTrue: [
 		number := 10 * number + readStream next digitValue.
-		power := power * 10.0 ].
+		power := power * 10 ].
+	number isZero ifTrue: [ ^ 0 ].
 	^ number / power

--- a/repository/STON-Tests.package/STONWriteReadTest.class/instance/testFloats.st
+++ b/repository/STON-Tests.package/STONWriteReadTest.class/instance/testFloats.st
@@ -2,9 +2,10 @@ tests
 testFloats
 	| floats serialization materialization |
 	floats := STON listClass withAll: ((-10 to: 10) collect: [ :each | each * Float pi ]).
+	"some problematic values:"
+	floats := floats , { 0.022999999999999854 . 4.999999999999996 . -4.999999999999996 . Float epsilon . Float fmin . -0.0 }.
 	serialization := self serialize: floats.
 	materialization := self materialize: serialization.
 	self assert: floats size equals: materialization size.
 	floats with: materialization do: [ :float :materializedFloat |
-		"Use #closeTo: instead of #= to increase portability"
-		self assert: float closeTo: materializedFloat ]
+		self assert: float equals: materializedFloat ]


### PR DESCRIPTION
Addresses issue #34 
Also adds problematic values to `STONWriteReadTest>>#testFloats`.
I'm not sure the fix got 100% of cases covered, but it's considerable improvement of the current state of things.