### PR TITLE
Pi value is '3.14159' and not '3.14149'

### DIFF
--- a/repository/STON-Tests.package/STONReaderTest.class/instance/testFloat.st
+++ b/repository/STON-Tests.package/STONReaderTest.class/instance/testFloat.st
@@ -3,7 +3,7 @@ testFloat
 	self assert: ((self materialize: '1.5') closeTo: 1.5).
 	self assert: ((self materialize: '-1.5') closeTo: -1.5).
 	self assert: (self materialize: '0.0') isZero.
-	self assert: (Float pi closeTo: (self materialize: '3.14149')).
+	self assert: (Float pi closeTo: (self materialize: '3.14159') precision: 0.00001).
 	self assert: (1/3 closeTo: (self materialize: '0.333333')).
 	self assert: (self materialize: '1.0e100') equals: 1.0e100.
 	self assert: (self materialize: '1.0e-100') equals: 1.0e-100.


### PR DESCRIPTION
This error was not detected before because of a bug in Pharo #closeTo: that will be fixed in Pharo 11