### PR TITLE
Fixing partial float detection

### DIFF
--- a/repository/STON-Core.package/STONReader.class/instance/parseNumber.st
+++ b/repository/STON-Core.package/STONReader.class/instance/parseNumber.st
@@ -13,7 +13,7 @@ parseNumber
 			(readStream peekFor: $.)
 				ifTrue: [ number := number + self parseNumberFraction. isFloat := true ].
 			((readStream peekFor: $e) or: [ readStream peekFor: $E ])
-				ifTrue: [ number := number * self parseNumberExponent ].
+				ifTrue: [ number := number * self parseNumberExponent. isFloat := true ].
 			isFloat
 				ifTrue: [ number := number asFloat ] ].
 	negated

--- a/repository/STON-Tests.package/STONWriteReadTest.class/instance/testFloats.st
+++ b/repository/STON-Tests.package/STONWriteReadTest.class/instance/testFloats.st
@@ -15,7 +15,7 @@ testFloats
 	check value: {
 		0.022999999999999854 . 4.999999999999996 . -4.999999999999996 . 0.333333333333 .
 		Float zero . Float negativeZero .
-		Float fmin . Float fmax . 5E-324 .
+		Float fmin . Float fmax . 5e-324 .
 		Float pi . Float e . 0.00001.
 		Float infinity . Float negativeInfinity }.
 

--- a/repository/STON-Tests.package/STONWriteReadTest.class/instance/testFloats.st
+++ b/repository/STON-Tests.package/STONWriteReadTest.class/instance/testFloats.st
@@ -15,7 +15,7 @@ testFloats
 	check value: {
 		0.022999999999999854 . 4.999999999999996 . -4.999999999999996 . 0.333333333333 .
 		Float zero . Float negativeZero .
-		Float fmin . Float fmax .
+		Float fmin . Float fmax . 5E-324 .
 		Float pi . Float e . 0.00001.
 		Float infinity . Float negativeInfinity }.
 


### PR DESCRIPTION
In GemStone `Float fmin` = `5E-324`.  In Pharo it is `5.0E-324`.  The issue is that both are floats and need to be detected as such.  This fix allows for both to be recognized as floats.