### PR TITLE
Conflicting contents

### DIFF
--- a/repository/STON-Core.package/Bag.extension/instance/stonOn..st
+++ b/repository/STON-Core.package/Bag.extension/instance/stonOn..st
@@ -4,4 +4,4 @@ stonOn: stonWriter
 
 	stonWriter
 		writeObject: self
-		do: [ stonWriter encodeMap: contents ]
+		do: [ stonWriter encodeMap: self contents ]


### PR DESCRIPTION
Without `self` keyword GemStone shows contents of the method. In this case it would show `Bag -> stonOn:` instead of the real contents.

Already covered by `testCollections`.