### PR TITLE
Additional check for accessors/slots usage

### DIFF
--- a/repository/STON-Core.package/STONWriter.class/instance/writeObject..st
+++ b/repository/STON-Core.package/STONWriter.class/instance/writeObject..st
@@ -1,10 +1,13 @@
 writing
 writeObject: anObject
 	| instanceVariableNames |
-	(instanceVariableNames := anObject class stonAllInstVarNames) isEmpty
-		ifTrue: [
+	instanceVariableNames := anObject stonUseAccessors 
+		ifTrue: [ anObject class allInstVarNames ]
+		ifFalse: [ anObject class stonAllInstVarNames ].
+	instanceVariableNames
+		ifEmpty: [
 			self writeObject: anObject do: [ self encodeMap: #() ] ]
-		ifFalse: [
+		ifNotEmpty: [
 			self writeObject: anObject streamMap: [ :dictionary |
 				instanceVariableNames do: [ :each |
 					(anObject stonUseAccessors 


### PR DESCRIPTION
The current code uses `#stonAllInstVarNames` which checks allSlots and returns them.  In order for accessor/slot split the fix detects the flag `#stoneUseAccessors` and uses correct code to get `#instanceVariableNames`.

The `testDomainObjectUsingAccessors` fails on GemStone before this fix.
